### PR TITLE
Remove static class emulation

### DIFF
--- a/lib/class.nusoap_base.php
+++ b/lib/class.nusoap_base.php
@@ -71,7 +71,7 @@ require_once('class.soap_server.php');*/
 
 // class variable emulation
 // cf. http://www.webkreator.com/php/techniques/php-static-class-variables.html
-$GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'] = 9;
+// $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'] = 9;
 
 /**
 *
@@ -133,6 +133,13 @@ class nusoap_base {
 	 * @access private
 	 */
 	var $debugLevel;
+    /**
+     * the global debug level for new instances
+     *
+     * @var int
+     * @access private
+     */
+    private static $globalDebugLevel = 9;
 
     /**
 	* set schema version
@@ -223,7 +230,8 @@ class nusoap_base {
 	* @access	public
 	*/
 	function nusoap_base() {
-		$this->debugLevel = $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'];
+		//$this->debugLevel = $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'];
+        $this->debugLevel = self::$globalDebugLevel;
 	}
 
 	/**
@@ -233,7 +241,8 @@ class nusoap_base {
 	* @access	public
 	*/
 	function getGlobalDebugLevel() {
-		return $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'];
+		//return $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'];
+        return self::$globalDebugLevel;
 	}
 
 	/**
@@ -243,7 +252,8 @@ class nusoap_base {
 	* @access	public
 	*/
 	function setGlobalDebugLevel($level) {
-		$GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'] = $level;
+		//$GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'] = $level;
+        self::$globalDebugLevel = $level;
 	}
 
 	/**
@@ -274,7 +284,7 @@ class nusoap_base {
 	*/
 	function debug($string){
 		if ($this->debugLevel > 0) {
-			$this->appendDebug($this->getmicrotime().' '.get_class($this).": $string\n");
+			$this->appendDebug($this->getmicrotime().' '.get_class($this).": $string\r\n");
 		}
 	}
 


### PR DESCRIPTION
Basically, remove static class emulation and update the class to be a proper static one.

This is done in order to solve an issue with PHPUnit, more info over here:
http://stackoverflow.com/questions/14607718/multiple-nusoap-clients-causes-undefined-index-transient-error
