### PR TITLE
Fixing bug with _transient gobal variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /vendor/
+*.sublime-project
+*.sublime-workspace
+/.phpintel/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 nusoap
 ======
 
-NuSphere's NuSOAP for Packagist/Composer
+A modification of the NuSoap implementation provided by forguesean. I forked his code in order to fix a bug I was having where with the _transient global variable a la: http://stackoverflow.com/questions/14607718/multiple-nusoap-clients-causes-undefined-index-transient-error

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fergusean/nusoap",
+    "name": "seismicmike/nusoap",
     "description": "NuSOAP re-packaged for Packagist/Composer",
     "license": "LGPLv2",
     "authors": [
@@ -10,6 +10,10 @@
         {
             "name": "Scott Nichol",
             "homepage": "http://sourceforge.net/u/snichol/profile/"
+        },
+        {
+            "name": "Mike Lewis",
+            "e-mail": "seismicmike@gmail.com"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "seismicmike/nusoap",
-    "description": "NuSOAP re-packaged for Packagist/Composer",
+    "description": "NuSOAP re-packaged for Packagist/Composer based on Fergusean with a bug fix.",
     "license": "LGPLv2",
     "authors": [
         {

--- a/lib/class.nusoap_base.php
+++ b/lib/class.nusoap_base.php
@@ -71,7 +71,6 @@ require_once('class.soap_server.php');*/
 
 // class variable emulation
 // cf. http://www.webkreator.com/php/techniques/php-static-class-variables.html
-$GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'] = 9;
 
 /**
 *
@@ -134,6 +133,8 @@ class nusoap_base {
 	 */
 	var $debugLevel;
 
+	private static $globalDebugLevel = 9;
+
     /**
 	* set schema version
 	*
@@ -141,7 +142,7 @@ class nusoap_base {
 	* @access   public
 	*/
 	var $XMLSchemaVersion = 'http://www.w3.org/2001/XMLSchema';
-	
+
     /**
 	* charset encoding for outgoing messages
 	*
@@ -223,7 +224,7 @@ class nusoap_base {
 	* @access	public
 	*/
 	function nusoap_base() {
-		$this->debugLevel = $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'];
+		$this->debugLevel = self::$globalDebugLevel;
 	}
 
 	/**
@@ -233,7 +234,7 @@ class nusoap_base {
 	* @access	public
 	*/
 	function getGlobalDebugLevel() {
-		return $GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'];
+		return self::$globalDebugLevel;
 	}
 
 	/**
@@ -243,7 +244,7 @@ class nusoap_base {
 	* @access	public
 	*/
 	function setGlobalDebugLevel($level) {
-		$GLOBALS['_transient']['static']['nusoap_base']['globalDebugLevel'] = $level;
+		self::$globalDebugLevel = $level;
 	}
 
 	/**
@@ -408,7 +409,7 @@ class nusoap_base {
 		$this->debug("in serialize_val: name=$name, type=$type, name_ns=$name_ns, type_ns=$type_ns, use=$use, soapval=$soapval");
 		$this->appendDebug('value=' . $this->varDump($val));
 		$this->appendDebug('attributes=' . $this->varDump($attributes));
-		
+
     	if (is_object($val) && get_class($val) == 'soapval' && (! $soapval)) {
     		$this->debug("serialize_val: serialize soapval");
         	$xml = $val->serialize($use);
@@ -982,7 +983,7 @@ function iso8601_to_timestamp($datestr){
 function usleepWindows($usec)
 {
 	$start = gettimeofday();
-	
+
 	do
 	{
 		$stop = gettimeofday();


### PR DESCRIPTION
Hi!

I've been using your nusoap package from Packagist for a while now and it's worked pretty well for me. Today, I came across a weird issue. I was getting an error about an undefined index "_transient". I googled and came up with http://stackoverflow.com/questions/14607718/multiple-nusoap-clients-causes-undefined-index-transient-error 

Apparently somebody called Scardetto had already patched this in their fork of nusoap but rather than trying to somehow trace that back to something that I could use with composer, I just decided to fork and patch your code.

So anyway, I figured I'd send this back upstream in case you're intreested. Here's the patch. You can pretty much ignore the changes to .gitignore, README, composer.json, etc.The material change is in lib/class.nusoap_base.php

Let me know if you have any questions.
Thanks
