### PR TITLE
Fix: Array to string conversion in .../nusoap/lib/class.wsdl.php

### DIFF
--- a/lib/class.soap_server.php
+++ b/lib/class.soap_server.php
@@ -991,6 +991,7 @@ class nusoap_server extends nusoap_base {
         	} else {
         		$SCHEME = 'http';
         	}
+			$SCRIPT_NAME = htmlspecialchars($SCRIPT_NAME, ENT_QUOTES | ENT_SUBSTITUTE, "UTF-8");
 			$soapaction = "$SCHEME://$SERVER_NAME$SCRIPT_NAME/$name";
 		}
 		if(false == $style) {

--- a/lib/class.wsdl.php
+++ b/lib/class.wsdl.php
@@ -1547,7 +1547,7 @@ class wsdl extends nusoap_base {
 				$rows = sizeof($value);
 				$contents = '';
 				foreach($value as $k => $v) {
-					$this->debug("serializing array element: $k, $v of type: $typeDef[arrayType]");
+					$this->debug("serializing array element: $k, ".json_encode($v)." of type: ".$typeDef['arrayType']);
 					//if (strpos($typeDef['arrayType'], ':') ) {
 					if (!in_array($typeDef['arrayType'],$this->typemap['http://www.w3.org/2001/XMLSchema'])) {
 					    $contents .= $this->serializeType('item', $typeDef['arrayType'], $v, $use);


### PR DESCRIPTION
Array to string conversion in .../nusoap/lib/class.wsdl.php:1550

$v can be an array that is perfectly serializable, but debug message messes it up.
